### PR TITLE
fix `update-rc.d` compatibility by resolving script name via readlink

### DIFF
--- a/web-applications/tiny-tiny-rss/tt-rss.init-d
+++ b/web-applications/tiny-tiny-rss/tt-rss.init-d
@@ -16,7 +16,7 @@
 # PATH should only include /usr/* if it runs after the mountnfs.sh script
 PATH="/sbin:/usr/sbin:/bin:/usr/bin"
 DESC="Tiny Tiny RSS update daemon"
-NAME="$(command basename "${0}")"
+NAME="$(command basename $(command readlink -f "${0}"))"
 DISABLED=0
 FORKING=0
 


### PR DESCRIPTION
`update-rc.d` creates symlinks of this script named like `/etc/rc3.d/S20tt-rss` and it fails on boot because tries to use defaults from non-existent `/etc/default/S20tt-rss`
